### PR TITLE
Update edit_tree dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 conllx = "0.12.1"
-edit_tree = "0.1"
+edit_tree = "0.1.1"
 failure = "0.1"
 numberer = "0.1"
 ordered-float = "1"


### PR DESCRIPTION
Since edit_tree::EditTree now has a nice Display implementation, this
change removes the wrapper type.