### PR TITLE
Dependency encoders: make the root relation label configurable

### DIFF
--- a/src/deprel/mod.rs
+++ b/src/deprel/mod.rs
@@ -45,7 +45,9 @@ mod tests {
     use super::{RelativePOSEncoder, RelativePositionEncoder};
     use crate::{EncodingProb, SentenceDecoder, SentenceEncoder};
 
-    static NON_PROJECTIVE_DATA: &'static str = "testdata/nonprojective.conll";
+    const NON_PROJECTIVE_DATA: &str = "testdata/nonprojective.conll";
+
+    const ROOT_RELATION: &str = "root";
 
     fn copy_sentence_without_deprels(sentence: &Sentence) -> Sentence {
         let mut copy = Sentence::new();
@@ -88,13 +90,13 @@ mod tests {
 
     #[test]
     fn relative_pos_position() {
-        let encoder = RelativePOSEncoder;
+        let encoder = RelativePOSEncoder::new(ROOT_RELATION);
         test_encoding(NON_PROJECTIVE_DATA, encoder);
     }
 
     #[test]
     fn relative_position() {
-        let encoder = RelativePositionEncoder;
+        let encoder = RelativePositionEncoder::new(ROOT_RELATION);
         test_encoding(NON_PROJECTIVE_DATA, encoder);
     }
 }


### PR DESCRIPTION
The root label used by post-processing was hardcoded to be
`ROOT`. However, this is incorrect for various schemes, including
universal dependencies. This change makes the root relation
configurable per encoder/decoder.

The part-of-speech tag of the root node is still fixed to `ROOT`. This
tag is only used internally and changing this would break existing
label files.

This issue was reported by @twuebi.