### PR TITLE
find_root_candidate: check that candidate attaches to ROOT token

### DIFF
--- a/src/deprel/post_processing.rs
+++ b/src/deprel/post_processing.rs
@@ -94,8 +94,16 @@ where
                 .iter()
                 // Find encodings with a root relation...
                 .filter(|e| e.encoding().label() == root_relation)
-                // ...that can be decoded.
-                .filter_map(|e| decode_fun(idx + 1, e.encoding()).map(|triple| (triple, e.prob())))
+                // ...that can be decoded and attaches to the root.
+                .filter_map(|e| {
+                    let triple = decode_fun(idx + 1, e.encoding())?;
+
+                    if triple.head() == 0 {
+                        Some((triple, e.prob()))
+                    } else {
+                        None
+                    }
+                })
                 .next()
         })
         .max_by_key(|(_, prob)| OrderedFloat(*prob))


### PR DESCRIPTION
Before this change find_root_candidate looked for an encoding that has
the root label and can be decoded.

Unfortunately, the Lassy treebank has some root edges that do not attach
to ROOT. find_root_candidate could find a root token that is not
attached to ROOT. To make things worse, in the case of a cycle between
such a token and another token, the cycle cannot be resolved.

This change adds an additional requirement to candidates, namely that
they should attach the token to ROOT after decoding.