### PR TITLE
Return concrete errors rather than failure::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ exclude = [
 [dependencies]
 conllu = "0.3"
 edit_tree = "0.1.1"
-failure = "0.1"
 numberer = "0.2"
 ordered-float = "1"
 petgraph = "0.4"
 serde = "1"
 serde_derive = "1"
+thiserror = "1"

--- a/src/deprel/error.rs
+++ b/src/deprel/error.rs
@@ -2,10 +2,10 @@ use std::fmt;
 
 use conllu::graph::{Node, Sentence};
 use conllu::token::Token;
-use failure::Fail;
+use thiserror::Error;
 
 /// Encoder errors.
-#[derive(Clone, Debug, Eq, Fail, PartialEq)]
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum EncodeError {
     /// The token does not have a head.
     MissingHead { token: usize, sent: Vec<String> },
@@ -95,13 +95,13 @@ impl fmt::Display for EncodeError {
 }
 
 /// Decoder errors.
-#[derive(Clone, Copy, Debug, Eq, Fail, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
 pub(crate) enum DecodeError {
     /// The head position is out of bounds.
-    #[fail(display = "position out of bounds")]
+    #[error("position out of bounds")]
     PositionOutOfBounds,
 
     /// The head part-of-speech tag does not occur in the sentence.
-    #[fail(display = "unknown part-of-speech tag")]
+    #[error("unknown part-of-speech tag")]
     InvalidPOS,
 }

--- a/src/deprel/relative_pos.rs
+++ b/src/deprel/relative_pos.rs
@@ -1,8 +1,9 @@
+use std::convert::Infallible;
+
 use std::collections::HashMap;
 
 use conllu::graph::{DepTriple, Node, Sentence};
 use conllu::token::Token;
-use failure::Error;
 use serde_derive::{Deserialize, Serialize};
 
 use super::{
@@ -191,7 +192,9 @@ impl RelativePOSEncoder {
 impl SentenceEncoder for RelativePOSEncoder {
     type Encoding = DependencyEncoding<RelativePOS>;
 
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+    type Error = EncodeError;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Self::Error> {
         let pos_table = self.pos_position_table(&sentence);
 
         let mut encoded = Vec::with_capacity(sentence.len());
@@ -238,7 +241,9 @@ impl SentenceEncoder for RelativePOSEncoder {
 impl SentenceDecoder for RelativePOSEncoder {
     type Encoding = DependencyEncoding<RelativePOS>;
 
-    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    type Error = Infallible;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Self::Error>
     where
         S: AsRef<[EncodingProb<Self::Encoding>]>,
     {

--- a/src/deprel/relative_position.rs
+++ b/src/deprel/relative_position.rs
@@ -1,5 +1,6 @@
+use std::convert::Infallible;
+
 use conllu::graph::{DepTriple, Sentence};
-use failure::Error;
 use serde_derive::{Deserialize, Serialize};
 
 use super::{
@@ -64,7 +65,9 @@ impl RelativePositionEncoder {
 impl SentenceEncoder for RelativePositionEncoder {
     type Encoding = DependencyEncoding<RelativePosition>;
 
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+    type Error = EncodeError;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Self::Error> {
         let mut encoded = Vec::with_capacity(sentence.len());
         for idx in 1..sentence.len() {
             let triple = sentence
@@ -88,7 +91,9 @@ impl SentenceEncoder for RelativePositionEncoder {
 impl SentenceDecoder for RelativePositionEncoder {
     type Encoding = DependencyEncoding<RelativePosition>;
 
-    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    type Error = Infallible;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Self::Error>
     where
         S: AsRef<[EncodingProb<Self::Encoding>]>,
     {

--- a/src/layer/error.rs
+++ b/src/layer/error.rs
@@ -1,8 +1,8 @@
-use failure::Fail;
+use thiserror::Error;
 
-#[derive(Clone, Debug, Eq, Fail, PartialEq)]
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
 pub enum EncodeError {
     /// The token does not have a label.
-    #[fail(display = "token without a label: '{}'", form)]
+    #[error("token without a label: '{form:?}'")]
     MissingLabel { form: String },
 }

--- a/src/layer/mod.rs
+++ b/src/layer/mod.rs
@@ -1,10 +1,9 @@
 //! CoNLL-X layer encoder.
 
-use std::convert::TryFrom;
+use std::convert::{Infallible, TryFrom};
 
 use conllu::graph::{Node, Sentence};
 use conllu::token::{Features, Token};
-use failure::Error;
 use serde_derive::{Deserialize, Serialize};
 
 use super::{EncodingProb, SentenceDecoder, SentenceEncoder};
@@ -127,7 +126,9 @@ impl LayerEncoder {
 impl SentenceDecoder for LayerEncoder {
     type Encoding = String;
 
-    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    type Error = Infallible;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Self::Error>
     where
         S: AsRef<[EncodingProb<Self::Encoding>]>,
     {
@@ -154,7 +155,9 @@ impl SentenceDecoder for LayerEncoder {
 impl SentenceEncoder for LayerEncoder {
     type Encoding = String;
 
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+    type Error = EncodeError;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Self::Error> {
         let mut encoding = Vec::with_capacity(sentence.len() - 1);
         for token in sentence.iter().filter_map(Node::token) {
             let label = token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! Label encoders.
 
+use std::error::Error;
+
 use conllu::graph::Sentence;
-use failure::Error;
 
 pub mod categorical;
 
@@ -56,7 +57,10 @@ where
 pub trait SentenceDecoder {
     type Encoding: ToOwned;
 
-    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    /// The decoding error type.
+    type Error: Error;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Self::Error>
     where
         S: AsRef<[EncodingProb<Self::Encoding>]>;
 }
@@ -68,6 +72,9 @@ pub trait SentenceDecoder {
 pub trait SentenceEncoder {
     type Encoding;
 
+    /// The encoding error type.
+    type Error: Error;
+
     /// Encode the given sentence.
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error>;
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Self::Error>;
 }


### PR DESCRIPTION
- Derive the `Error` trait using `thiserror` crate.
- Modify `SentenceEncoder`/`SentenceDecoder` to return concrete error
  types. The error type is specified using an associated type of these
  traits.